### PR TITLE
Remove old socket if exist

### DIFF
--- a/Furious/Widget/Application.py
+++ b/Furious/Widget/Application.py
@@ -126,11 +126,19 @@ class SingletonApplication(ApplicationExitHelper):
             # Do not start
             return True
         else:
+            # Remove the old socket file if it exists
+            socket_path = QLocalServer.removeServer(self.serverName)
+            if socket_path:
+                logger.info(f"Old socket file removed: {self.serverName}")
+            else:
+                logger.info(f"No existing socket file found for: {self.serverName}")
+
             # New instance
             self.server.newConnection.connect(self.showExistingApp)
 
             if not self.server.listen(self.serverName):
                 # Do not start
+                logger.error(f"Unable to listen on server: {self.serverName}")
                 return True
 
             # Start


### PR DESCRIPTION
If Furious terminates incorrectly, a socket remains that prevents the application from starting until the system is rebooted or the file is manually removed with the command `rm ${TMPDIR}891ad49d-8996-43cb-820c-d9baf42a04de`.

Steps to reproduce:
1. Execute `killall "Furious-GUI"` and after that Furious will not be able to start.
2. After executing `rm ${TMPDIR}891ad49d-8996-43cb-820c-d9baf42a04de`, Furious starts successfully.

A check has been added to detect the presence of a socket before starting. If a socket exists, it will first be deleted, and then a new instance will be launched.