### PR TITLE
macOS Dock icon visibility feature

### DIFF
--- a/Deploy.py
+++ b/Deploy.py
@@ -56,6 +56,9 @@ if PLATFORM == 'Windows':
 elif PLATFORM == 'Darwin':
     NUITKA_BUILD = (
         f'python -m nuitka '
+        f'--include-module=objc '
+        f'--include-module=AppKit '
+        f'--include-module=Cocoa '
         f'--standalone --plugin-enable=pyside6 '
         f'--disable-console '
         f'--assume-yes-for-downloads '

--- a/Furious/Widget/Application.py
+++ b/Furious/Widget/Application.py
@@ -288,14 +288,16 @@ class Application(ApplicationFactory, SingletonApplication):
         NSApplication.sharedApplication().setActivationPolicy_(policy)
 
     def eventFilter(self, obj, event):
-        # Show Dock icon on macOS when window is shown and hide only when window is closed (not minimized)
+        # Show Dock icon on macOS when window is shown
+        # and hide only when window is closed (not minimized)
         if PLATFORM == 'Darwin' and obj is getattr(self, 'mainWindow', None):
-            if event.type() == QtCore.QEvent.Show:
+            if event.type() == QtCore.QEvent.Type.Show:
                 self._setDockIconVisible(True)
-            elif event.type() == QtCore.QEvent.Hide:
+            elif event.type() == QtCore.QEvent.Type.Hide:
                 # Hide Dock icon when window is closed (not minimized)
                 if not self.mainWindow.isMinimized():
                     self._setDockIconVisible(False)
+
         return super().eventFilter(obj, event)
 
     def exit(self, exitcode=0):
@@ -400,6 +402,7 @@ class Application(ApplicationFactory, SingletonApplication):
 
             self.mainWindow = AppMainWindow()
             self.systemTray = SystemTrayIcon()
+
             if PLATFORM == 'Darwin':
                 # Install event filter for main window to track show/hide
                 self.mainWindow.installEventFilter(self)

--- a/Furious/Widget/Application.py
+++ b/Furious/Widget/Application.py
@@ -278,6 +278,26 @@ class Application(ApplicationFactory, SingletonApplication):
 
         logger.info('final cleanup done')
 
+    def _setDockIconVisible(self, visible: bool):
+        if PLATFORM != 'Darwin':
+            return
+
+        from AppKit import NSApplication
+
+        policy = 0 if visible else 1
+        NSApplication.sharedApplication().setActivationPolicy_(policy)
+
+    def eventFilter(self, obj, event):
+        # Show Dock icon on macOS when window is shown and hide only when window is closed (not minimized)
+        if PLATFORM == 'Darwin' and obj is getattr(self, 'mainWindow', None):
+            if event.type() == QtCore.QEvent.Show:
+                self._setDockIconVisible(True)
+            elif event.type() == QtCore.QEvent.Hide:
+                # Hide Dock icon when window is closed (not minimized)
+                if not self.mainWindow.isMinimized():
+                    self._setDockIconVisible(False)
+        return super().eventFilter(obj, event)
+
     def exit(self, exitcode=0):
         self.setExitingFlag(True)
 
@@ -380,6 +400,11 @@ class Application(ApplicationFactory, SingletonApplication):
 
             self.mainWindow = AppMainWindow()
             self.systemTray = SystemTrayIcon()
+            if PLATFORM == 'Darwin':
+                # Install event filter for main window to track show/hide
+                self.mainWindow.installEventFilter(self)
+                # Hide Dock icon initially, keeping only the tray icon visible
+                self._setDockIconVisible(False)
 
             if AppSettings.isStateON_('DarkMode'):
                 self.switchToDarkMode()

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ icmplib
 sysproxy; sys_platform == "win32"
 darkdetect; sys_platform != "darwin"
 darkdetect[macos-listener]; sys_platform == "darwin"
+pyobjc-core; sys_platform == "darwin"
+pyobjc-framework-Cocoa; sys_platform == "darwin"


### PR DESCRIPTION
Added a feature to show the Dock icon on macOS when the window is open, and hide it only when the window is closed (not minimized).

P.S. The tray icon is always shown.