### PR TITLE
docs(windows): require amd64 wintun.dll for TUN mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ pip install Furious-GUI
 * 🔄 [Subscription Management](https://github.com/LorenEteval/Furious/wiki/Subscription-Management)
 * 📦 [Install From PyPI](https://github.com/LorenEteval/Furious/wiki/Install-From-PyPI)
 
+### Windows TUN (`wintun.dll`)
+
+The Windows release is **amd64 (x64)** only. The [official Wintun](https://www.wintun.net/) package ships **one `wintun.dll` per CPU architecture** under `wintun\bin\` (for example `amd64`, `arm`, `arm64`, and `x86`).
+
+You must use the DLL from **`wintun\bin\amd64\wintun.dll`**. Loading a DLL from another architecture (for example `arm64` or `x86`) can **crash TUN mode**.
+
+Full setup (including where to place the file and administrator steps) is documented in **[TUN Mode](https://github.com/LorenEteval/Furious/wiki/TUN-Mode)**.
+
 ## Contributing
 
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/LorenEteval/Furious)


### PR DESCRIPTION
## Summary

Documents that the official Wintun zip contains **multiple** `wintun.dll` builds under `wintun\\bin\\` (`amd64`, `arm`, `arm64`, `x86`), while the Furious Windows release is **amd64 only**. Using a DLL from the wrong folder can **crash TUN mode**.

## Changes

- Add a **Windows TUN (`wintun.dll`)** subsection under **Wiki** in `README.md`.
- Link to the existing **[TUN Mode](https://github.com/LorenEteval/Furious/wiki/TUN-Mode)** wiki for full install steps.

## Follow-up (optional)

Please mirror the same guidance on the wiki **TUN Mode → Windows** section so it stays aligned with the README.

Closes nothing — documentation only.

Made with [Cursor](https://cursor.com)