### PR TITLE
Fix macOS JSON editor window controls

### DIFF
--- a/Furious/Window/TextEditorWindow.py
+++ b/Furious/Window/TextEditorWindow.py
@@ -76,7 +76,19 @@ class TextEditorWindow(AppQMainWindow):
         super().__init__(*args, **kwargs)
 
         self.customWindowTitle = ''
-        self.setWindowModality(QtCore.Qt.WindowModality.WindowModal)
+        if PLATFORM == 'Darwin':
+            # Window-modal child windows are rendered as macOS sheets
+            # without traffic-light controls.
+            self.setWindowFlags(
+                self.windowFlags()
+                | QtCore.Qt.WindowType.Window
+                | QtCore.Qt.WindowType.WindowTitleHint
+                | QtCore.Qt.WindowType.WindowSystemMenuHint
+                | QtCore.Qt.WindowType.WindowMinimizeButtonHint
+                | QtCore.Qt.WindowType.WindowCloseButtonHint
+            )
+        else:
+            self.setWindowModality(QtCore.Qt.WindowModality.WindowModal)
         self.setFixedSize(450, int(450 * GOLDEN_RATIO))
 
         # Current editing index

--- a/Furious/Window/TextEditorWindow.py
+++ b/Furious/Window/TextEditorWindow.py
@@ -87,6 +87,7 @@ class TextEditorWindow(AppQMainWindow):
                 | QtCore.Qt.WindowType.WindowMinimizeButtonHint
                 | QtCore.Qt.WindowType.WindowCloseButtonHint
             )
+            self.setWindowModality(QtCore.Qt.WindowModality.ApplicationModal)
         else:
             self.setWindowModality(QtCore.Qt.WindowModality.WindowModal)
         self.setFixedSize(450, int(450 * GOLDEN_RATIO))


### PR DESCRIPTION
Hello. This PR fixes the JSON configuration editor window on macOS.

Previously, opening it via `Customize JSON Configuration...` displayed the editor without the native macOS title bar and traffic-light window controls, so the window could only be closed through `File > Close Window`.

The editor now uses explicit top-level window flags on macOS so the native title bar and close/minimize controls are shown.