### PR TITLE
Fix macOS monochrome tray icon state styling

### DIFF
--- a/Furious/Qt/QtGui.py
+++ b/Furious/Qt/QtGui.py
@@ -28,6 +28,8 @@ logger = logging.getLogger(__name__)
 
 __all__ = [
     'bootstrapIcon',
+    'bootstrapIconMask',
+    'bootstrapIconWithOpacity',
     'bootstrapIconWhite',
     'AppQIcon',
     'AppQAction',
@@ -53,6 +55,49 @@ def iconFn(prefix, name):
 
 bootstrapIcon = functools.partial(iconFn, 'bootstrap')
 bootstrapIconWhite = functools.partial(iconFn, 'bootstrap/white')
+
+
+def setIconAsMask(icon):
+    if hasattr(icon, 'setIsMask'):
+        icon.setIsMask(True)
+
+    return icon
+
+
+@functools.lru_cache(None)
+def bootstrapIconMask(name):
+    return setIconAsMask(bootstrapIconWhite(name))
+
+
+@functools.lru_cache(None)
+def bootstrapIconWithOpacity(name, opacity, isMask=False):
+    sourceIcon = bootstrapIconWhite(name)
+    icon = AppQIcon('')
+
+    for iconSize in (16, 18, 22, 24, 32, 64):
+        sourcePixmap = sourceIcon.pixmap(QtCore.QSize(iconSize, iconSize))
+
+        if sourcePixmap.isNull():
+            continue
+
+        pixmap = QPixmap(sourcePixmap.size())
+        pixmap.setDevicePixelRatio(sourcePixmap.devicePixelRatio())
+        pixmap.fill(QtCore.Qt.GlobalColor.transparent)
+
+        painter = QPainter(pixmap)
+        painter.setOpacity(opacity)
+        painter.drawPixmap(0, 0, sourcePixmap)
+        painter.end()
+
+        icon.addPixmap(pixmap)
+
+    if icon.isNull():
+        return sourceIcon
+
+    if isMask:
+        return setIconAsMask(icon)
+    else:
+        return icon
 
 
 class AppQAction(Mixins.QTranslatable, Mixins.ThemeAware, QAction):

--- a/Furious/Widget/SystemTrayIcon.py
+++ b/Furious/Widget/SystemTrayIcon.py
@@ -30,6 +30,8 @@ logger = logging.getLogger(__name__)
 
 __all__ = ['SystemTrayIcon']
 
+_MACOS_DISCONNECTED_MONOCHROME_OPACITY = 0.55
+
 _TRANSLATABLE_ADMIN = [
     _('Administrator'),
 ]
@@ -142,11 +144,31 @@ class SystemTrayIcon(
             switchMonochrome()
 
     def setMonochromeIcon(self):
-        self.setMonochromeIconByTheme(APP().theme())
+        if APP().isSystemTrayConnected():
+            self.setConnectedMonochromeIcon()
+        else:
+            self.setDisconnectedMonochromeIcon()
+
+    def setConnectedMonochromeIcon(self):
+        if PLATFORM == 'Darwin':
+            self.setIcon(bootstrapIconMask('monochrome-rocket-takeoff.svg'))
+        else:
+            self.setMonochromeIconByTheme(APP().theme())
+
+    def setDisconnectedMonochromeIcon(self):
+        if PLATFORM == 'Darwin':
+            icon = bootstrapIconWithOpacity(
+                'monochrome-rocket-takeoff.svg',
+                _MACOS_DISCONNECTED_MONOCHROME_OPACITY,
+                isMask=True,
+            )
+            self.setIcon(icon)
+        else:
+            self.setMonochromeIconByTheme(APP().theme())
 
     def setDisconnectedIcon(self):
         if AppSettings.isStateON_('UseMonochromeTrayIcon'):
-            self.setMonochromeIcon()
+            self.setDisconnectedMonochromeIcon()
 
             return
 
@@ -162,7 +184,7 @@ class SystemTrayIcon(
 
     def setConnectedIcon(self):
         if AppSettings.isStateON_('UseMonochromeTrayIcon'):
-            self.setMonochromeIcon()
+            self.setConnectedMonochromeIcon()
 
             return
 
@@ -201,7 +223,7 @@ class SystemTrayIcon(
     def themeChangedCallback(self, theme):
         if AppSettings.isStateON_('UseMonochromeTrayIcon'):
             # 'theme' is not used. Instead, always query current theme
-            self.setMonochromeIconByTheme(APP().theme())
+            self.setMonochromeIcon()
 
             return
 


### PR DESCRIPTION
Hi.
This PR updates the macOS monochrome tray icon behavior so connection state is visible:
- connected: uses the normal full-opacity monochrome tray icon
- disconnected: uses the same template/mask icon with reduced opacity
