### PR TITLE
Fix subscription update: preserve base64 result and set User-Agent

### DIFF
--- a/Furious/Widget/UserServersQTableWidget.py
+++ b/Furious/Widget/UserServersQTableWidget.py
@@ -208,34 +208,44 @@ class SubscriptionManager(WebGETManager):
 
         data = networkReply.readAll().data()
 
+        uris = None
+        lastException = None
+
         try:
-            uris = list(
-                filter(
-                    lambda x: x != '',
-                    PyBase64Encoder.decode(data).decode().split('\n'),
-                )
-            )
+            decoded = PyBase64Encoder.decode(data).decode()
         except Exception as ex:
             # Any non-exit exceptions
+
+            lastException = ex
 
             logger.error(
                 f'parse base64 share link from \'{webURL}\' failed: {ex}. '
                 f'Try to fall back to plain text'
             )
+        else:
+            # pybase64 decodes leniently and happily turns plain text into
+            # garbage bytes, so only accept the base64 result when it actually
+            # looks like share links.
+            if '://' in decoded:
+                uris = list(filter(lambda x: x != '', decoded.split('\n')))
 
-        try:
-            uris = list(
-                filter(
-                    lambda x: x != '',
-                    data.decode().split('\n'),
+        if uris is None:
+            try:
+                uris = list(
+                    filter(
+                        lambda x: x != '',
+                        data.decode().split('\n'),
+                    )
                 )
-            )
-        except Exception as ex:
-            # Any non-exit exceptions
+            except Exception as ex:
+                # Any non-exit exceptions
 
-            logger.error(f'parse share link from \'{webURL}\' failed: {ex}')
+                lastException = ex
 
-            failureArgs.append({'error': classname(ex), **kwargs})
+                logger.error(f'parse share link from \'{webURL}\' failed: {ex}')
+
+        if uris is None:
+            failureArgs.append({'error': classname(lastException), **kwargs})
         else:
             logger.info(
                 f'update subs ({remark}, {webURL}) success. Got {len(uris)} share link'
@@ -264,7 +274,15 @@ class SubscriptionManager(WebGETManager):
 
         logActionMessage = kwargs.pop('logActionMessage', False)
 
-        self.webGET(url, logActionMessage=logActionMessage, **kwargs)
+        # Some providers reject the default Qt User-Agent (e.g. with 503),
+        # so identify ourselves explicitly.
+        request = QNetworkRequest(QtCore.QUrl(url))
+        request.setRawHeader(
+            b'User-Agent',
+            f'{APPLICATION_NAME}/{APPLICATION_VERSION}'.encode(),
+        )
+
+        self.webGET(request, logActionMessage=logActionMessage, **kwargs)
 
     def updateSubsByUnique(self, unique: str, **kwargs):
         depthMap = kwargs.get('depthMap', {'depth': 1})


### PR DESCRIPTION
## Summary

Subscription updates were failing for typical providers. Two regressions, both in `Furious/Widget/UserServersQTableWidget.py`:

1. **`SubscriptionManager.successCallback` overwrites the base64 result.** In 88e447d the plain‑text fallback was added after the base64 `try`/`except` but placed *unconditionally* — so when base64 decode succeeded (the common case), the second block ran anyway and replaced the parsed share links with a single line of raw base64. Those garbage URIs then failed `factory.isValid()` and were silently dropped, leaving the user with the existing servers deleted and nothing in their place.

   Fix: only run the plain‑text decode when the base64 branch did **not** yield share links. A `'://' in decoded` guard is added because `pybase64` in lenient mode (the default in `Encoder.py`) happily turns plain text into garbage bytes and would otherwise be reported as a false‑positive success. `failureArgs` is now populated only when both decoders fail.

2. **No `User-Agent` on subscription requests.** Some providers respond with HTTP 503 to Qt's default UA. `updateSubsByWebGET` now builds a `QNetworkRequest` and sets `User-Agent: Furious/<version>`, which gets the same 200 response that `curl` does.

Verified locally against a base64 provider that previously returned 503 + 0 imported servers — after the patch, 47 `vless://` entries import correctly. Plain‑text subscriptions (the feature added in 88e447d) still work.

## Test plan

- [x] Base64-encoded subscription URL imports all share links (was: 0 imported / "Update subscription failed")
- [x] Plain-text subscription URL still works (regression check for 88e447d's intent)
- [x] Provider that rejected the default Qt UA with 503 now returns 200 and imports